### PR TITLE
add custom Max Size of available area

### DIFF
--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -44,6 +44,9 @@ class SideMenu extends StatefulWidget {
   /// Close Icon
   final Icon? closeIcon;
 
+  /// Max Size of available area (For custom sizes (the default is MediaQuery.of(context).size))
+  final Size? maxSize;
+
   /// Menu that should be in side menu
   ///
   /// generally a [SingleChildScrollView] with a [Column]
@@ -122,6 +125,7 @@ class SideMenu extends StatefulWidget {
     this.type = SideMenuType.shrikNRotate,
     this.maxMenuWidth = 275.0,
     bool inverse = false,
+    this.maxSize,
     this.isDismissible = false,
     this.barrierColor,
     this.curve = Curves.fastLinearToSlowEaseIn,

--- a/lib/src/shrik_slide_menu.dart
+++ b/lib/src/shrik_slide_menu.dart
@@ -4,7 +4,7 @@ class ShrinkSlideSideMenuState extends SideMenuState {
   @override
   Widget build(BuildContext context) {
     final mq = MediaQuery.of(context);
-    final size = mq.size;
+    final size = widget.maxSize ?? mq.size;
     final statusBarHeight = mq.padding.top;
 
     return Material(

--- a/lib/src/shrink_slide_rotate_menu.dart
+++ b/lib/src/shrink_slide_rotate_menu.dart
@@ -4,7 +4,7 @@ class ShrinkSlideRotateSideMenuState extends SideMenuState {
   @override
   Widget build(BuildContext context) {
     final mq = MediaQuery.of(context);
-    final size = mq.size;
+    final size = widget.maxSize ?? mq.size;
     final statusBarHeight = mq.padding.top;
 
     return Material(

--- a/lib/src/slide_menu.dart
+++ b/lib/src/slide_menu.dart
@@ -4,7 +4,7 @@ class SlideSideMenuState extends SideMenuState {
   @override
   Widget build(BuildContext context) {
     final mq = MediaQuery.of(context);
-    final size = mq.size;
+    final size = widget.maxSize ?? mq.size;
     final statusBarHeight = mq.padding.top;
 
     return Material(

--- a/lib/src/slide_rotate_menu.dart
+++ b/lib/src/slide_rotate_menu.dart
@@ -4,7 +4,7 @@ class SlideRotateSideMenuState extends SideMenuState {
   @override
   Widget build(BuildContext context) {
     final mq = MediaQuery.of(context);
-    final size = mq.size;
+    final size = widget.maxSize ?? mq.size;
     final statusBarHeight = mq.padding.top;
 
     return Material(


### PR DESCRIPTION
We display the side menu bar only on a part of the screen, so in order to display the offset correctly - we pass a custom size (instead of the default `MediaQuery.of(context).size`)
![iPad Air 2021-12-06 11-28-19](https://user-images.githubusercontent.com/50525087/144812736-ddbdfc6f-7daa-4e32-924e-625cca55fa85.png)
![iPhone 13 Pro Max 2021-12-06 11-31-56](https://user-images.githubusercontent.com/50525087/144813172-bd20e43e-cce5-4d1f-8710-806eaade522e.png)


